### PR TITLE
Properly uninstall module if installation fails

### DIFF
--- a/blocklink.php
+++ b/blocklink.php
@@ -91,7 +91,7 @@ class BlockLink extends Module
 		{
 			// If there are no colums implemented by the template, throw an error and uninstall the module
 			$this->_errors[] = $this->l('This module needs to be hooked to a column, but your theme does not implement one');
-			parent::uninstall();
+			$this->uninstall();
 
 			return false;
 		}


### PR DESCRIPTION
#1 

Installation of the module requires left or right columns active. If they're not, it's supposed to uninstall itself. But it never deleted the tables it had already created, leading to complications when trying to reinstall the module.

Yum, low hanging fruit!